### PR TITLE
Speed up ListDir

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     docker:
       - image: circleci/golang:1.11.4
-    working_directory: /go/src/github.com/citymapper/go-minipypi
+    working_directory: /home/circleci/citymapper/go-minipypi
     environment:
       TEST_RESULTS: &test_results /tmp/test-results
       OUTPUT_BIN: &output_bin /tmp/bin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,41 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/golang:1.11.4
+    working_directory: /go/src/github.com/citymapper/go-minipypi
+    environment:
+      TEST_RESULTS: &test_results /tmp/test-results
+      OUTPUT_BIN: &output_bin /tmp/bin
+
+    steps:
+      - checkout
+      - run: mkdir -p "$TEST_RESULTS"
+      - run: mkdir -p "$OUTPUT_BIN"
+
+      - run: go get github.com/jstemmer/go-junit-report
+
+      - run:
+          name: Run unit tests
+          command: |
+            trap "go-junit-report <${TEST_RESULTS}/go-test.out > ${TEST_RESULTS}/go-test-report.xml" EXIT
+            go test -v 2>&1 | tee ${TEST_RESULTS}/go-test.out
+
+      - run: go build
+
+      - run:
+          name: Create build artifact
+          command: |
+            gzip go-minipypi
+            mv -f go-minipypi.gz "$OUTPUT_BIN/go-minipypi-`uname -s`-`uname -m`.gz"
+
+      - store_artifacts:
+          path: *test_results
+          destination: raw-test-output
+
+      - store_test_results:
+          path: *test_results
+
+      - store_artifacts:
+          path: *output_bin
+          destination: bin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
           name: Run unit tests
           command: gotestsum --junitfile ${TEST_RESULTS}/go-test-report.xml
 
-      - run: go build
+      - run: go build -ldflags "-X main.date=`date -u +%Y-%m-%dT%H:%M:%SZ` -X main.commit=${CIRCLE_SHA1}"
 
       - run:
           name: Create build artifact

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,13 +13,9 @@ jobs:
       - run: mkdir -p "$TEST_RESULTS"
       - run: mkdir -p "$OUTPUT_BIN"
 
-      - run: go get github.com/jstemmer/go-junit-report
-
       - run:
           name: Run unit tests
-          command: |
-            trap "go-junit-report <${TEST_RESULTS}/go-test.out > ${TEST_RESULTS}/go-test-report.xml" EXIT
-            go test -v 2>&1 | tee ${TEST_RESULTS}/go-test.out
+          command: gotestsum --junitfile ${TEST_RESULTS}/go-test-report.xml
 
       - run: go build
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+go-minipypi
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,38 @@
+# This is an example goreleaser.yaml file with some sane defaults.
+# Make sure to check the documentation at http://goreleaser.com
+before:
+  hooks:
+    # you may remove this if you don't use vgo
+    - go mod download
+    # you may remove this if you don't need go generate
+    - go generate ./...
+builds:
+- env:
+  - CGO_ENABLED=0
+  goos:
+    - darwin
+    - linux
+    - freebsd
+    - windows
+  goarch:
+    - amd64
+archive:
+  replacements:
+    darwin: Darwin
+    linux: Linux
+    windows: Windows
+    386: i386
+    amd64: x86_64
+  format_overrides:
+    - goos: windows
+      format: zip
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,9 +23,7 @@ archive:
     windows: Windows
     386: i386
     amd64: x86_64
-  format_overrides:
-    - goos: windows
-      format: zip
+  format: binary
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/README.md
+++ b/README.md
@@ -28,3 +28,28 @@ Installation
 Notes:
 ------
 It requires a config file, see `config.yml`. Drop the `credentialsfile` parameter to use the [default AWS credentials chain](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials).
+
+Release
+-------
+
+go-minipypi uses [goreleaser](https://github.com/goreleaser/goreleaser) locally for releases.
+
+1. Install [goreleaser](https://goreleaser.com/install/)
+
+2. Ensure you're on a clean master, and tag the current commit for release -
+
+   ```sh
+   git tag -a "v0.4.0"
+   ```
+
+3. Do a dry-run of the release if necessary and check the artifacts in `dist/` -
+
+   ```sh
+   goreleaser --skip-publish
+   ```
+
+4. Using your GitHub token, complete the release -
+
+   ```sh
+   GITHUB_TOKEN=your_github_token_with_release_privileges goreleaser
+   ```

--- a/README.md
+++ b/README.md
@@ -1,44 +1,25 @@
 go-minipypi
 ===========
 
-Bare minimums implementation of a Pypi server that proxies all requests to an S3 bucket.
+A bare minimum implementation of a PyPI server that proxies all requests to an S3 bucket.
 
 This was implemented by looking what was required to get pip install commands such as this one working:
 > pip install -v  --no-index --find-links=http://localhost:8080/ -r requirements.txt
 
-it does the job.
+Installation
+------------
 
+1. Install [go 1.11](https://golang.org/dl/) or later.
 
-Instalation
------------
+2. Clone this repository to somewhere outside of your GOPATH.
 
-1. Install go:
+3. Build the code:
 
-	```
-	brew install go
-	```
-
-2. Setup your GOPATH env variable and pull the code:
-
-	```
-	go get github.com/citymapper/go-minipypi
-	```
-
-3. Install the requirements (if you haven't done so already)
-
-	```
-	go get github.com/aws/aws-sdk-go/aws
-	go get gopkg.in/yaml.v2
-	```
-
-4. Build the code:
-
-	```
-	cd $GOPATH/src/github.com/citymapper/go-minipypi
+	```sh
 	go build .
 	```
 
-5. Run it:
+4. Run it:
 
 	```
 	./go-minipypi
@@ -46,5 +27,4 @@ Instalation
 
 Notes:
 ------
-Its requires a config file, see config.yml.
-It requires a ini file that holds the AWS credentials. See aws_credentials.ini
+It requires a config file, see `config.yml`. Drop the `credentialsfile` parameter to use the [default AWS credentials chain](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials).

--- a/circle.yml
+++ b/circle.yml
@@ -1,9 +1,0 @@
-test:
-    post:
-        - strip go-minipypi
-        - gzip go-minipypi
-        - mkdir -p bin/
-        - mv -f go-minipypi.gz bin/go-minipypi-`uname -s`-`uname -m`.gz
-general:
-    artifacts:
-        - "bin/"

--- a/frontend.go
+++ b/frontend.go
@@ -76,6 +76,7 @@ func (ctx WebServerConfigs) handleListDir(w http.ResponseWriter, path string) {
 	fileList, err := handlePypiListDir(ctx.fetcher, path)
 	if err != nil {
 		desc := fmt.Sprintf("\"LISTDIR %v\" 400 - err: %v", path, err)
+		log.Println(desc)
 		http.Error(w, desc, http.StatusBadRequest)
 		return
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/citymapper/go-minipypi
+
+require (
+	github.com/aws/aws-sdk-go v1.16.1
+	github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8
+	gopkg.in/yaml.v2 v2.2.2
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,7 @@
+github.com/aws/aws-sdk-go v1.16.1 h1:x/KXjZHqwEXjW9i83HgvV17G3cxqSxZ21vzOzWF39Dg=
+github.com/aws/aws-sdk-go v1.16.1/go.mod h1:es1KtYUFs7le0xQ3rOihkuoVD90z7D0fR2Qm4S00/gU=
+github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8 h1:12VvqtR6Aowv3l/EQUlocDHW2Cp4G9WJVH7uyH8QFJE=
+github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -15,6 +16,12 @@ type Configs struct {
 	CacheConfigs CacheConfigs
 	S3configs    S3configs
 }
+
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
 
 func genConfig(filename string) {
 	cfg := &Configs{
@@ -38,6 +45,8 @@ func genConfig(filename string) {
 }
 
 func main() {
+	fmt.Printf("go-minipypi - %v, commit %v, built at %v\n", version, commit, date)
+
 	cfg := Configs{}
 
 	var configFile = flag.String("config", "config.yml", "config file")

--- a/main.go
+++ b/main.go
@@ -72,7 +72,6 @@ func isValidConfig(config Configs) bool {
 	valid = valid && config.WebConfigs.Port > 0
 	valid = valid && config.WebConfigs.Port < 65535
 	valid = valid && len(config.S3configs.BucketName) > 0
-	valid = valid && len(config.S3configs.CredentialsFile) > 0
 	valid = valid && len(config.S3configs.Region) > 0
 	return valid
 }

--- a/pypiisms.go
+++ b/pypiisms.go
@@ -26,26 +26,22 @@ func handlePypiFileNames(key string) string {
 func handlePypiListDir(fetcher FileFetcher, path string) ([]ListDirEntry, error) {
 	prefix := strings.TrimPrefix(path, "/")  // remove initial /
 	prefix = strings.TrimSuffix(prefix, "/") // and last one
+	prefix = strings.Replace(prefix, "-", "_", -1)
+
 
 	if len(prefix) < 1 {
 		return nil, fmt.Errorf("expected a directory to list")
 	}
 
-	// case-insensitive search, search for X* + x*
-	lowerFiles, err := fetcher.ListDir(strings.ToLower(prefix))
+	files, err := fetcher.ListDir(prefix)
 	if err != nil {
-		return lowerFiles, err
-	}
-	upperFiles, err := fetcher.ListDir(strings.ToUpper(prefix))
-	if err != nil {
-		return upperFiles, err
+		return files, err
 	}
 
-	// now merge both and filter by normalized prefix comparison.
-	allFiles := append(lowerFiles, upperFiles...)
+	// now filter by normalized prefix comparison.
 	normalizedPrefix := normalizeFileName(prefix)
 	var results []ListDirEntry
-	for _, entry := range allFiles {
+	for _, entry := range files {
 		fileName := normalizeFileName(entry.Name)
 		if strings.HasPrefix(fileName, normalizedPrefix) {
 			results = append(results, entry)

--- a/pypiisms.go
+++ b/pypiisms.go
@@ -32,12 +32,11 @@ func handlePypiListDir(fetcher FileFetcher, path string) ([]ListDirEntry, error)
 	}
 
 	// case-insensitive search, search for X* + x*
-	firstLetter := prefix[0:1]
-	lowerFiles, err := fetcher.ListDir(strings.ToLower(firstLetter))
+	lowerFiles, err := fetcher.ListDir(strings.ToLower(prefix))
 	if err != nil {
 		return lowerFiles, err
 	}
-	upperFiles, err := fetcher.ListDir(strings.ToUpper(firstLetter))
+	upperFiles, err := fetcher.ListDir(strings.ToUpper(prefix))
 	if err != nil {
 		return upperFiles, err
 	}

--- a/s3fetcher.go
+++ b/s3fetcher.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"log"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -20,9 +22,15 @@ type S3configs struct {
 // NewS3Fetcher is a S3 backed implementation of the FileFetcher interface.
 // it does the setup of the S3 service session state required to implement FileFetcher interface
 func NewS3Fetcher(cfg S3configs) FileFetcher {
-	svc := s3.New(session.New(
-		aws.NewConfig().WithRegion(cfg.Region).WithCredentials(
-			credentials.NewSharedCredentials(cfg.CredentialsFile, "default"))))
+	awsCfg := aws.NewConfig().WithRegion(cfg.Region)
+	if cfg.CredentialsFile != "" {
+		log.Printf("using AWS credentials from %s", cfg.CredentialsFile)
+		awsCfg = awsCfg.WithCredentials(credentials.NewSharedCredentials(cfg.CredentialsFile, "default"))
+	} else {
+		log.Print("no AWS credentials file specified, using the default credentials chain")
+	}
+
+	svc := s3.New(session.New(awsCfg))
 	cfg.s3svc = svc
 
 	return cfg


### PR DESCRIPTION
instead of fetching all objects starting with the first letter of the prefix (which is time consuming due to the sheer number of objects on the buckets), use the whole prefix, so for instance for the sentry-sdk package, the prefix to use would be:
`sentry-sdk` instead of just `s`
It does also change any `-` in the package name to `_`, as it seems to be that all packages with dashes in their name are stored with underscores instead.