### PR TITLE
fix config for newer goreleaser versions

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,14 +16,15 @@ builds:
     - windows
   goarch:
     - amd64
-archive:
-  replacements:
-    darwin: Darwin
-    linux: Linux
-    windows: Windows
-    386: i386
-    amd64: x86_64
-  format: binary
+archives:
+  -
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+    format: binary
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
The `archive` config section has been removed in favour of [`archives`](https://goreleaser.com/customization/archive/)

> We now allow multiple archives, so the archive statement will be removed.
> removed 2019-12-27 (v0.124.0)

https://goreleaser.com/deprecations/#archive

https://github.com/goreleaser/goreleaser/pull/942

