### PR TITLE
Increase expiresecs

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -3,7 +3,7 @@ webconfigs:
   port: 8080
   basepath: /
 cacheconfigs:
-  expiresecs: 120
+  expiresecs: 900
 s3configs:
   bucketname: citymapper-packages
   credentialsfile: aws_credentials.ini


### PR DESCRIPTION
From 2min to 15min, in the hope this will improve the speed when installing packages

Most builds take more than 2min to install python packages via pip. Therefore it refetches the same list of objects from the S3 bucket multiple times during install/build.

Increase the cache expiry/timeout means we should be maximising and actually re-using entries from the cache more often, instead of fetching the list of objects from s3 again.